### PR TITLE
Refactor: Introduce Pluggable Messaging System Abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,16 @@ openssl = { version = "0.10", features = ["vendored"] }
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+# MQTT Adapter Dependencies
+rumqttc = "0.25.0"
+async_trait = "0.1.77" # For MessageSystem trait
+thiserror = "1.0.58"   # For custom error types
+rand = "0.8"           # For nanoid generation in mqtt_adapter
+
+[dev-dependencies]
+testcontainers = "0.20.1"
+testcontainers-modules = { version = "0.6.0", features = ["kafka", "mosquitto"] }
+uuid = { version = "1.8.0", features = ["v4"] }
+# tokio is already a main dependency with "full" features
+# serde_json is already a main dependency

--- a/src/kafka_adapter.rs
+++ b/src/kafka_adapter.rs
@@ -1,0 +1,338 @@
+// src/kafka_adapter.rs
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures_util::StreamExt;
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
+    error::KafkaError,
+    message::{Message as KafkaMessageRd, OwnedMessage},
+    producer::{FutureProducer, FutureRecord},
+    Message,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use thiserror::Error;
+
+use crate::messaging::MessageSystem;
+// Message type for consuming from Kafka (e.g., messages to be sent to Telegram)
+use crate::kafka_processing::outgoing::OutgoingMessage;
+// Message type for publishing to Kafka (e.g., messages received from Telegram)
+use crate::telegram_handler::incoming::IncomingMessage;
+
+#[derive(Error, Debug)]
+pub enum KafkaAdapterError {
+    #[error("Kafka error: {0}")]
+    Kafka(#[from] KafkaError),
+    #[error("Serialization/Deserialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("Failed to send message: {0}")]
+    SendError(String),
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+    #[error("Consumer creation error: {0}")]
+    ConsumerCreationError(String),
+}
+
+#[derive(Clone)] // Added Clone
+pub struct KafkaAdapterConfig {
+    pub brokers: String,
+    pub group_id: String,
+    pub consume_topic: String,
+    pub produce_topic: String, // Topic to publish messages to
+}
+
+pub struct KafkaAdapter {
+    config: KafkaAdapterConfig,
+    consumer: Option<StreamConsumer>,
+    producer: FutureProducer,
+}
+
+impl KafkaAdapter {
+    pub fn new(config: KafkaAdapterConfig) -> Result<Self, KafkaAdapterError> {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", &config.brokers)
+            .set("message.timeout.ms", "5000")
+            .create()?;
+
+        Ok(Self {
+            config,
+            consumer: None,
+            producer,
+        })
+    }
+}
+
+#[async_trait]
+impl MessageSystem for KafkaAdapter {
+    type ConsumeMessage = OutgoingMessage;
+    type PublishMessage = IncomingMessage; // Changed to IncomingMessage
+    type Error = KafkaAdapterError;
+
+    async fn connect(&mut self) -> Result<(), Self::Error> {
+        tracing::info!(brokers = %self.config.brokers, group_id = %self.config.group_id, consume_topic = %self.config.consume_topic, publish_topic = %self.config.produce_topic, "Attempting to connect Kafka adapter");
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("group.id", &self.config.group_id)
+            .set("bootstrap.servers", &self.config.brokers)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "true")
+            //.set("auto.offset.reset", "earliest") // Or "latest" depending on desired behavior
+            .create()
+            .map_err(|e| KafkaAdapterError::ConsumerCreationError(e.to_string()))?;
+
+        consumer
+            .subscribe(&[&self.config.consume_topic])
+            .map_err(|e| KafkaAdapterError::ConnectionError(e.to_string()))?;
+
+        self.consumer = Some(consumer);
+        tracing::info!("Kafka consumer connected and subscribed successfully.");
+        Ok(())
+    }
+
+    async fn consume<F, Fut>(&mut self, mut callback: F) -> Result<(), Self::Error>
+    where
+        F: FnMut(Self::ConsumeMessage) -> Fut + Send + Sync + 'static, // Changed to ConsumeMessage
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let consumer = self
+            .consumer
+            .as_mut()
+            .ok_or_else(|| KafkaAdapterError::ConnectionError("Consumer not initialized. Call connect first.".to_string()))?;
+
+        tracing::info!(topic = %self.config.consume_topic, "Starting Kafka message consumption loop...");
+        loop {
+            match consumer.recv().await {
+                Ok(borrowed_message) => {
+                    // Process the message
+                    let owned_message = borrowed_message.detach();
+                    if let Some(payload) = owned_message.payload() {
+                        match serde_json::from_slice::<Self::ConsumeMessage>(payload) { // Changed to ConsumeMessage
+                            Ok(consumed_msg) => {
+                                tracing::debug!(topic = %self.config.consume_topic, "Successfully deserialized message from Kafka");
+                                // Invoke the callback with the deserialized message and await its completion
+                                callback(consumed_msg).await;
+                            }
+                            Err(e) => {
+                                tracing::error!(topic = %self.config.consume_topic, error = %e, "Error deserializing message from Kafka payload");
+                                tracing::debug!(raw_payload = ?String::from_utf8_lossy(payload), "Problematic Kafka payload");
+                                // Potentially, we could pass the error to the callback or an error handler
+                            }
+                        }
+                    } else {
+                        tracing::warn!(topic = %self.config.consume_topic, "Received Kafka message with empty payload");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(topic = %self.config.consume_topic, error = %e, "Error consuming message from Kafka");
+                    // Decide if this error is fatal or if the loop should continue
+                    // For now, we return the error, which will stop the loop.
+                    return Err(KafkaAdapterError::Kafka(e));
+                }
+            }
+        }
+    }
+
+    async fn publish(&self, message: &Self::PublishMessage) -> Result<(), Self::Error> { // Changed signature
+        tracing::debug!(topic = %self.config.produce_topic, "Attempting to publish message type: {:?}", std::any::type_name::<Self::PublishMessage>());
+        let payload = serde_json::to_string(message)?; // message is already a reference
+
+        let record = FutureRecord::to(&self.config.produce_topic)
+            .payload(&payload)
+            .key("default_key"); // TODO: Determine a meaningful key, perhaps from message source or type
+
+        match self.producer.send(record, Duration::from_secs(5)).await { // Increased timeout slightly
+            Ok(delivery) => {
+                tracing::info!(topic = %self.config.produce_topic, partition = %delivery.0, offset = %delivery.1, "Message published successfully");
+                Ok(())
+            }
+            Err((e, _owned_message)) => {
+                tracing::error!(topic = %self.config.produce_topic, error = %e, "Failed to send message");
+                Err(KafkaAdapterError::SendError(e.to_string()))
+            }
+        }
+    }
+}
+
+// Ensure the module is declared in main.rs or lib.rs
+// pub mod kafka_adapter;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka_processing::outgoing::{OutgoingMessage, TextMessageData, MessageTarget};
+    use crate::telegram_handler::incoming::{IncomingMessage, IncomingMessageType, TelegramMessageData, MessageSource, FileInfo};
+    use crate::messaging::MessageSystem;
+    use testcontainers_modules::kafka::Kafka;
+    use testcontainers::clients;
+    use rdkafka::producer::{FutureProducer, FutureRecord, DefaultProducerContext};
+    use rdkafka::consumer::{StreamConsumer, Consumer, CommitMode};
+    use rdkafka::config::ClientConfig as RdkafkaClientConfig; // Aliased to avoid conflict with KafkaAdapterConfig
+    use rdkafka::message::Message as RdkafkaMessage; // Aliased
+    use std::time::Duration;
+    use uuid::Uuid;
+    use chrono::Utc;
+    use teloxide::types::Message as TeloxideMessage; // For dummy TelegramMessage
+
+    fn create_sample_incoming_message(text: String) -> IncomingMessage {
+        // Create a dummy Teloxide Message
+        let dummy_teloxide_msg: TeloxideMessage = serde_json::from_value(serde_json::json!({
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": false, "first_name": "Test"},
+            "text": text,
+        })).unwrap();
+
+        IncomingMessage {
+            message_type: IncomingMessageType::TelegramMessage(TelegramMessageData {
+                message: dummy_teloxide_msg,
+                downloaded_files: Vec::<FileInfo>::new(),
+            }),
+            timestamp: Utc::now(),
+            source: MessageSource {
+                platform: "test_platform".to_string(),
+                bot_id: Some(123),
+                bot_username: Some("test_bot".to_string()),
+            },
+        }
+    }
+
+    fn create_sample_outgoing_message(text: String) -> OutgoingMessage {
+        OutgoingMessage {
+            message_type: crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(TextMessageData {
+                text,
+                buttons: None,
+                reply_keyboard: None,
+                parse_mode: None,
+                disable_web_page_preview: None,
+            }),
+            timestamp: Utc::now(),
+            target: MessageTarget {
+                platform: "test_platform".to_string(),
+                chat_id: 123,
+                thread_id: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_kafka_publish_incoming_message() {
+        let docker = clients::Cli::default();
+        let kafka_node = docker.run(Kafka::default());
+        let bootstrap_servers = format!("localhost:{}", kafka_node.get_host_port_ipv4(9093));
+
+        let topic_name = format!("test_publish_topic_{}", Uuid::new_v4());
+
+        let adapter_config = KafkaAdapterConfig {
+            brokers: bootstrap_servers.clone(),
+            group_id: "test_publish_group".to_string(),
+            consume_topic: "dummy_consume_for_publish_test".to_string(), // Not used in this test directly by adapter
+            produce_topic: topic_name.clone(),
+        };
+
+        let mut adapter = KafkaAdapter::new(adapter_config).expect("Failed to create adapter");
+        // For publish-only, connect might not be strictly necessary if producer is created in new,
+        // but MessageSystem expects connect to be callable.
+        // KafkaAdapter's connect also sets up a consumer, which isn't ideal for a publish-only test.
+        // However, producer is created in `new` and available.
+
+        let sample_message = create_sample_incoming_message("Hello Kafka from Test!".to_string());
+        adapter.publish(&sample_message).await.expect("Publish failed");
+
+        // Setup a separate consumer to verify the message
+        let mut consumer_config = RdkafkaClientConfig::new();
+        consumer_config
+            .set("bootstrap.servers", &bootstrap_servers)
+            .set("group.id", "verify_consumer_group")
+            .set("auto.offset.reset", "earliest");
+
+        let consumer: StreamConsumer<DefaultProducerContext> = consumer_config.create().expect("Failed to create test consumer");
+        consumer.subscribe(&[&topic_name]).expect("Test consumer subscribe failed");
+
+        let message_stream = consumer.stream();
+        let received_message = tokio::time::timeout(Duration::from_secs(10), message_stream.recv())
+            .await
+            .expect("Timeout waiting for message")
+            .expect("Error receiving message from Kafka");
+
+        consumer.commit_message(&received_message, CommitMode::Async).unwrap();
+
+        let payload_str = std::str::from_utf8(received_message.payload().unwrap()).unwrap();
+        let received_deserialized: IncomingMessage = serde_json::from_str(payload_str).expect("Failed to deserialize consumed message");
+
+        if let IncomingMessageType::TelegramMessage(tm_data) = received_deserialized.message_type {
+            if let IncomingMessageType::TelegramMessage(sm_data) = sample_message.message_type {
+                 assert_eq!(tm_data.message.text(), sm_data.message.text());
+            } else {
+                panic!("Sample message was not TelegramMessage type");
+            }
+        } else {
+            panic!("Received message was not TelegramMessage type");
+        }
+        assert_eq!(received_deserialized.source.platform, sample_message.source.platform);
+    }
+
+
+    #[tokio::test]
+    async fn test_kafka_consume_outgoing_message() {
+        let docker = clients::Cli::default();
+        let kafka_node = docker.run(Kafka::default());
+        let bootstrap_servers = format!("localhost:{}", kafka_node.get_host_port_ipv4(9093));
+
+        let topic_name = format!("test_consume_topic_{}", Uuid::new_v4());
+
+        let adapter_config = KafkaAdapterConfig {
+            brokers: bootstrap_servers.clone(),
+            group_id: "test_consume_group".to_string(),
+            consume_topic: topic_name.clone(),
+            produce_topic: "dummy_produce_for_consume_test".to_string(), // Not used
+        };
+
+        let mut adapter = KafkaAdapter::new(adapter_config).expect("Failed to create adapter");
+        adapter.connect().await.expect("Adapter connect failed");
+
+        let sample_message = create_sample_outgoing_message("Hello Adapter, from Kafka!".to_string());
+
+        // Setup a producer to send a message to the topic the adapter consumes from
+        let producer: FutureProducer = RdkafkaClientConfig::new()
+            .set("bootstrap.servers", &bootstrap_servers)
+            .set("message.timeout.ms", "5000")
+            .create()
+            .expect("Failed to create test producer");
+
+        let payload = serde_json::to_string(&sample_message).expect("Failed to serialize sample OutgoingMessage");
+        let record = FutureRecord::to(&topic_name).payload(&payload).key("test_key");
+
+        producer.send(record, Duration::from_secs(5)).await.expect("Test producer failed to send").expect("Delivery error");
+        tracing::info!("Test message sent to Kafka topic {}", topic_name);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        tokio::spawn(async move {
+            adapter.consume(move |consumed_message: OutgoingMessage| {
+                let tx_clone = tx.clone();
+                async move {
+                    tx_clone.send(consumed_message).await.expect("Failed to send consumed message via channel");
+                }
+            }).await.expect("Consume loop failed");
+        });
+
+        let received_message = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("Timeout waiting for consumed message via channel")
+            .expect("Channel closed before message received");
+
+        if let crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(received_text_data) = received_message.message_type {
+             if let crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(sent_text_data) = sample_message.message_type {
+                assert_eq!(received_text_data.text, sent_text_data.text);
+             } else {
+                panic!("Sample message was not TextMessage type");
+             }
+        } else {
+            panic!("Received message was not TextMessage type");
+        }
+        assert_eq!(received_message.target.chat_id, sample_message.target.chat_id);
+    }
+}

--- a/src/kafka_processing/mod.rs
+++ b/src/kafka_processing/mod.rs
@@ -1,8 +1,8 @@
-use crate::outgoing::{OutgoingMessage, OutgoingMessageType};
+use crate::kafka_processing::outgoing::{OutgoingMessage, OutgoingMessageType}; // Adjusted path due to `pub mod outgoing`
 use crate::utils::{create_markup, create_reply_keyboard};
-use futures_util::StreamExt;
-use rdkafka::consumer::StreamConsumer;
-use rdkafka::message::Message as KafkaMessageRd;
+// futures_util::StreamExt; // Removed
+// rdkafka::consumer::StreamConsumer; // Removed
+// rdkafka::message::Message as KafkaMessageRd; // Removed
 use std::path::Path;
 use teloxide::{
     payloads::{
@@ -16,44 +16,11 @@ use teloxide::{
 
 pub mod outgoing;
 
-pub async fn start_kafka_consumer_loop(
-    bot_consumer_clone: Bot,
-    consumer: StreamConsumer,
-    kafka_out_topic_clone: String,
-) {
-    tracing::info!(topic = %kafka_out_topic_clone, "Starting Kafka consumer stream for Telegram output...");
-    let mut stream = consumer.stream();
-    while let Some(result) = stream.next().await {
-        match result {
-            Ok(kafka_msg) => {
-                tracing::debug!(topic = %kafka_msg.topic(), partition = %kafka_msg.partition(), offset = %kafka_msg.offset(), "Consumed message from Kafka");
-                if let Some(payload) = kafka_msg.payload() {
-                    match serde_json::from_slice::<OutgoingMessage>(payload) {
-                        Ok(out_msg) => {
-                            if let Err(e) =
-                                handle_outgoing_message(&bot_consumer_clone, out_msg).await
-                            {
-                                tracing::error!(topic = %kafka_msg.topic(), error = ?e, "Error handling OutgoingMessage");
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!(topic = %kafka_msg.topic(), error = %e, "Error deserializing message from Kafka payload");
-                            tracing::debug!(raw_payload = ?String::from_utf8_lossy(payload), "Problematic Kafka payload");
-                        }
-                    }
-                } else {
-                    tracing::warn!(topic = %kafka_msg.topic(), partition = %kafka_msg.partition(), offset = %kafka_msg.offset(), "Received Kafka message with empty payload");
-                }
-            }
-            Err(e) => {
-                tracing::error!(topic = %kafka_out_topic_clone, error = %e, "Error consuming message from Kafka");
-            }
-        }
-    }
-    tracing::warn!(topic = %kafka_out_topic_clone, "Kafka consumer stream ended.");
-}
+// start_kafka_consumer_loop has been removed as its functionality is now part of KafkaAdapter.
 
-async fn handle_outgoing_message(
+// This function remains for now, as it handles the Telegram-specific sending logic.
+// It will likely be called by the callback provided to KafkaAdapter::consume.
+pub async fn handle_outgoing_message(
     bot: &Bot,
     message: OutgoingMessage,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 use dotenv::dotenv;
-use rdkafka::config::ClientConfig;
-use rdkafka::consumer::{Consumer, StreamConsumer};
-use rdkafka::producer::FutureProducer;
+// Kafka-specific rdkafka imports are not needed when MQTT is active
+// use rdkafka::config::ClientConfig;
+// use rdkafka::producer::FutureProducer;
 use std::env;
 use std::sync::Arc;
 use teloxide::dispatching::UpdateFilterExt;
 use teloxide::types::Update;
 use teloxide::{dptree, prelude::*};
 use tracing_subscriber::{EnvFilter, fmt};
+
+// Module declarations
+mod messaging;
+mod kafka_adapter; // Active
+mod mqtt_adapter;  // Keep for potential switch
 
 mod structs;
 use structs::{ImageStorageDir, KafkaInTopic};
@@ -18,10 +23,24 @@ use telegram_handler::{callback_query_handler, message_handler, message_reaction
 mod utils;
 
 mod kafka_processing;
-use kafka_processing::*;
+use kafka_processing::handle_outgoing_message; // Used by both consumer callbacks
+use kafka_processing::outgoing::OutgoingMessage;
+use crate::telegram_handler::incoming::IncomingMessage;
+
+// Imports for MessageSystem and adapters
+use crate::messaging::MessageSystem;
+use crate::kafka_adapter::{KafkaAdapter, KafkaAdapterConfig, KafkaAdapterError}; // Active
+use crate::mqtt_adapter::{MqttAdapter, MqttAdapterConfig, MqttAdapterError};   // Keep for commented section
+
+// Type alias for the MessageSystem trait object
+// For Kafka:
+type DynMessageSystem = Arc<dyn MessageSystem<ConsumeMessage = OutgoingMessage, PublishMessage = IncomingMessage, Error = KafkaAdapterError> + Send + Sync>;
+// For MQTT (illustrative):
+// type DynMessageSystem = Arc<dyn MessageSystem<ConsumeMessage = OutgoingMessage, PublishMessage = IncomingMessage, Error = MqttAdapterError> + Send + Sync>;
+
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     dotenv().ok();
 
     let subscriber = fmt::Subscriber::builder()
@@ -37,74 +56,123 @@ async fn main() {
     let telegram_token =
         env::var("TELEGRAM_BOT_TOKEN").expect("FATAL: TELEGRAM_BOT_TOKEN not set in environment");
 
-    let kafka_broker = env::var("KAFKA_BROKER").unwrap_or_else(|_| {
-        tracing::info!("KAFKA_BROKER not set, defaulting to localhost:9092");
-        "localhost:9092".to_string()
-    });
-    tracing::info!(kafka_broker = %kafka_broker, "Using Kafka broker");
+    // Kafka specific env vars
+    let kafka_brokers = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
+    let kafka_in_topic_val = env::var("KAFKA_IN_TOPIC").unwrap_or_else(|_| "com.sectorflabs.ratatoskr.in".to_string());
+    let kafka_out_topic_val = env::var("KAFKA_OUT_TOPIC").unwrap_or_else(|_| "com.sectorflabs.ratatoskr.out".to_string());
 
-    let kafka_in_topic_val = env::var("KAFKA_IN_TOPIC").unwrap_or_else(|_| {
-        tracing::info!("KAFKA_IN_TOPIC not set, defaulting to com.sectorflabs.ratatoskr.in");
-        "com.sectorflabs.ratatoskr.in".to_string()
-    });
-    let kafka_in_topic = KafkaInTopic(kafka_in_topic_val.clone());
-    tracing::info!(kafka_in_topic = %kafka_in_topic.0, "Using Kafka IN topic");
+    let kafka_in_topic_dependency = KafkaInTopic(kafka_in_topic_val.clone());
 
-    let kafka_out_topic = env::var("KAFKA_OUT_TOPIC").unwrap_or_else(|_| {
-        tracing::info!("KAFKA_OUT_TOPIC not set, defaulting to com.sectorflabs.ratatoskr.out");
-        "com.sectorflabs.ratatoskr.out".to_string()
-    });
-    tracing::info!(kafka_out_topic = %kafka_out_topic, "Using Kafka OUT topic");
-
-    let image_storage_dir = env::var("IMAGE_STORAGE_DIR").unwrap_or_else(|_| {
-        tracing::info!("IMAGE_STORAGE_DIR not set, defaulting to ./images");
-        "./files/in".to_string()
-    });
-    let image_storage_dir = ImageStorageDir(image_storage_dir.clone());
-    tracing::info!(image_storage_dir = %image_storage_dir.0, "Using image storage directory");
+    let image_storage_dir = env::var("IMAGE_STORAGE_DIR").unwrap_or_else(|_| "./files/in".to_string());
+    let image_storage_dir_dependency = ImageStorageDir(image_storage_dir.clone());
 
     let bot = Bot::new(telegram_token.clone());
+    let bot_for_consumer_task = bot.clone();
 
-    let producer: Arc<FutureProducer> = Arc::new(
-        ClientConfig::new()
-            .set("bootstrap.servers", &kafka_broker)
-            .create()
-            .unwrap_or_else(|e| {
-                tracing::error!(error = %e, "Kafka producer creation error");
-                panic!("Kafka producer creation error: {}", e);
-            }),
-    );
-    tracing::info!("Kafka producer created successfully.");
+    // TODO: Implement a mechanism to select the messaging system at runtime (e.g., via config).
 
-    let consumer: StreamConsumer = ClientConfig::new()
-        .set("group.id", "ratatoskr-bot-consumer")
-        .set("bootstrap.servers", &kafka_broker)
-        .set("enable.partition.eof", "false")
-        .set("session.timeout.ms", "6000")
-        .set("enable.auto.commit", "true")
-        .create()
-        .unwrap_or_else(|e| {
-            tracing::error!(error = %e, "Kafka consumer creation error");
-            panic!("Kafka consumer creation error: {}", e);
-        });
-    tracing::info!("Kafka consumer created successfully.");
+    // --- Kafka Adapter Setup (Default) ---
+    tracing::info!("Active Setup: Using Kafka Adapter");
+    let kafka_adapter_config = KafkaAdapterConfig {
+        brokers: kafka_brokers.clone(),
+        group_id: "ratatoskr-bot-consumer".to_string(),
+        consume_topic: kafka_out_topic_val.clone(),
+        produce_topic: kafka_in_topic_val.clone(),
+    };
 
-    consumer.subscribe(&[&kafka_out_topic]).unwrap_or_else(|e| {
-        tracing::error!(topic = %kafka_out_topic, error = %e, "Failed to subscribe to Kafka topic");
-        panic!(
-            "Failed to subscribe to Kafka topic {}: {}",
-            kafka_out_topic, e
-        );
+    let mut consume_adapter = KafkaAdapter::new(kafka_adapter_config.clone())
+        .expect("Failed to create KafkaAdapter for consumption");
+
+    let mut publish_adapter = KafkaAdapter::new(kafka_adapter_config)
+        .expect("Failed to create KafkaAdapter for publishing");
+
+    tracing::info!("Connecting consumer KafkaAdapter...");
+    consume_adapter.connect().await.expect("Failed to connect consumer KafkaAdapter");
+    tracing::info!("Consumer KafkaAdapter connected successfully.");
+
+    // For Kafka, publish_adapter doesn't strictly need connect() if producer is created in new().
+    let shared_publish_system: DynMessageSystem = Arc::new(publish_adapter); // DynMessageSystem uses KafkaAdapterError here
+
+    tokio::spawn(async move {
+        tracing::info!("Starting Kafka consumer loop...");
+        let consume_result = consume_adapter.consume(|message: OutgoingMessage| {
+            let bot_clone = bot_for_consumer_task.clone();
+            async move {
+                tracing::debug!(message_type = ?message.message_type, "Received message from Kafka");
+                if let Err(e) = handle_outgoing_message(&bot_clone, message).await {
+                    tracing::error!(error = ?e, "Error handling OutgoingMessage from Kafka");
+                }
+            }
+        }).await;
+
+        if let Err(e) = consume_result {
+            tracing::error!(error = ?e, "Kafka consumption loop failed: {:?}", e);
+        } else {
+            tracing::info!("Kafka consumption loop finished.");
+        }
     });
-    tracing::info!(topic = %kafka_out_topic, "Subscribed to Kafka topic successfully.");
+    // --- End of Kafka Adapter Setup ---
 
-    let bot_consumer_clone = bot.clone();
-    let kafka_out_topic_clone = kafka_out_topic.clone();
-    tokio::spawn(start_kafka_consumer_loop(
-        bot_consumer_clone,
-        consumer,
-        kafka_out_topic_clone,
-    ));
+
+    // --- Illustrative MQTT Adapter Setup (Commented out) ---
+    /*
+    tracing::info!("Commented Setup: Using MQTT Adapter");
+
+    let mqtt_broker_addr = env::var("MQTT_BROKER_ADDR").unwrap_or_else(|_| "localhost".to_string());
+    let mqtt_broker_port = env::var("MQTT_BROKER_PORT")
+        .map(|p| p.parse::<u16>().unwrap_or(1883))
+        .unwrap_or(1883);
+    let mqtt_consume_topic = env::var("MQTT_TG_OUTGOING_TOPIC").unwrap_or_else(|_| "ratatoskr/telegram/outgoing".to_string());
+    let mqtt_publish_topic = env::var("MQTT_TG_INCOMING_TOPIC").unwrap_or_else(|_| "ratatoskr/telegram/incoming".to_string());
+
+    let mqtt_adapter_config = MqttAdapterConfig {
+        broker_address: mqtt_broker_addr,
+        broker_port: mqtt_broker_port,
+        client_id_prefix: "ratatoskr_mqtt_".to_string(),
+        consume_topic: mqtt_consume_topic.clone(),
+        publish_topic: mqtt_publish_topic.clone(),
+        consume_qos: rumqttc::QoS::AtLeastOnce,
+        publish_qos: rumqttc::QoS::AtLeastOnce,
+        keep_alive_interval: std::time::Duration::from_secs(30),
+    };
+
+    let mut mqtt_consume_adapter = MqttAdapter::new(mqtt_adapter_config.clone())
+        .expect("Failed to create MQTT consume adapter");
+
+    let mut mqtt_publish_adapter = MqttAdapter::new(mqtt_adapter_config)
+        .expect("Failed to create MQTT publish adapter");
+
+    tracing::info!("Connecting MQTT consume adapter...");
+    mqtt_consume_adapter.connect().await.expect("Failed to connect MQTT consume adapter");
+    tracing::info!("MQTT consume adapter connected.");
+
+    tracing::info!("Connecting MQTT publish adapter (initializes client and subscribes)...");
+    mqtt_publish_adapter.connect().await.expect("Failed to connect MQTT publish adapter");
+    tracing::info!("MQTT publish adapter client initialized and subscribed.");
+
+    // let shared_publish_system: DynMessageSystem = Arc::new(mqtt_publish_adapter); // DynMessageSystem should use MqttAdapterError for this block
+
+    tokio::spawn(async move {
+        tracing::info!("Starting MQTT consumer loop (topic: {})...", mqtt_consume_adapter.config.consume_topic);
+        let consume_result = mqtt_consume_adapter.consume(|message: OutgoingMessage| {
+            let bot_clone = bot_for_consumer_task.clone();
+            async move {
+                tracing::debug!(message_type = ?message.message_type, "Received message from MQTT");
+                if let Err(e) = handle_outgoing_message(&bot_clone, message).await {
+                    tracing::error!(error = ?e, "Error handling OutgoingMessage from MQTT");
+                }
+            }
+        }).await;
+
+        if let Err(e) = consume_result {
+            tracing::error!(error = ?e, "MQTT consumption loop failed: {:?}", e);
+        } else {
+            tracing::info!("MQTT consumption loop finished (this might indicate an issue if it wasn't intentional).");
+        }
+    });
+    */
+    // --- End of Illustrative MQTT Adapter Setup ---
+
 
     let handler = dptree::entry()
         .branch(Update::filter_message().endpoint(message_handler))
@@ -112,9 +180,11 @@ async fn main() {
         .branch(Update::filter_message_reaction_updated().endpoint(message_reaction_handler));
 
     Dispatcher::builder(bot, handler)
-        .dependencies(dptree::deps![producer, kafka_in_topic, image_storage_dir])
+        .dependencies(dptree::deps![shared_publish_system, kafka_in_topic_dependency, image_storage_dir_dependency])
         .enable_ctrlc_handler()
         .build()
         .dispatch()
         .await;
+
+    Ok(())
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,0 +1,41 @@
+// src/messaging.rs
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+
+/// A generic trait for interacting with a messaging system.
+#[async_trait]
+pub trait MessageSystem: Send + Sync + 'static {
+    /// The type of message consumed from the system.
+    /// Must be Deserializable, Send, Sync, Debug, and Clone.
+    /// 'static lifetime for Deserialize ensures it can be deserialized from any lifetime, common for message queues.
+    type ConsumeMessage: for<'de> Deserialize<'de> + Send + Sync + std::fmt::Debug + Clone;
+
+    /// The type of message published to the system.
+    /// Must be Serializable, Send, Sync, Debug, and Clone.
+    type PublishMessage: Serialize + Send + Sync + std::fmt::Debug + Clone;
+
+    /// The type of error that can occur when interacting with the system.
+    /// Must implement standard Error trait and be Send + Sync.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Establishes a connection to the messaging system.
+    /// This might be a no-op for some systems or involve complex setup for others.
+    async fn connect(&mut self) -> Result<(), Self::Error>;
+
+    /// Starts consuming messages from the system.
+    ///
+    /// The callback `F` is an async function/closure that processes each `ConsumeMessage`.
+    /// The consumer loop should continue until an unrecoverable error occurs or
+    /// the system signals a shutdown (if applicable).
+    async fn consume<F, Fut>(&mut self, callback: F) -> Result<(), Self::Error>
+    where
+        F: FnMut(Self::ConsumeMessage) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static;
+
+    /// Sends a message to the system.
+    ///
+    /// Takes a reference to `PublishMessage` to allow for non-consuming publication
+    /// if the message needs to be retained or sent elsewhere.
+    async fn publish(&self, message: &Self::PublishMessage) -> Result<(), Self::Error>;
+}

--- a/src/mqtt_adapter.rs
+++ b/src/mqtt_adapter.rs
@@ -1,0 +1,359 @@
+// src/mqtt_adapter.rs
+
+use async_trait::async_trait;
+use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, Packet, QoS, SubscribeFilter};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::sync::Mutex; // For EventLoop if needed for advanced scenarios, or if consume is &self
+
+use crate::messaging::MessageSystem;
+use crate::kafka_processing::outgoing::OutgoingMessage; // ConsumeMessage type
+use crate::telegram_handler::incoming::IncomingMessage; // PublishMessage type
+
+#[derive(Debug, Clone)]
+pub struct MqttAdapterConfig {
+    pub broker_address: String,
+    pub broker_port: u16,
+    pub client_id_prefix: String, // Will append a random suffix for uniqueness
+    pub consume_topic: String,
+    pub publish_topic: String,
+    pub consume_qos: QoS,
+    pub publish_qos: QoS,
+    pub keep_alive_interval: Duration,
+}
+
+#[derive(Error, Debug)]
+pub enum MqttAdapterError {
+    #[error("MQTT client error: {0}")]
+    MqttClient(#[from] rumqttc::ClientError),
+    #[error("MQTT connection error: {0}")]
+    MqttConnection(#[from] rumqttc::ConnectionError),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Subscription failed: {0}")]
+    SubscriptionFailed(String),
+    #[error("Publish failed: {0}")]
+    PublishFailed(String),
+    #[error("Consume loop not started or failed")]
+    ConsumeLoopNotRunning,
+    #[error("Message deserialization error: {0}")]
+    Deserialization(String), // Specific for payload deserialization issues
+}
+
+pub struct MqttAdapter {
+    config: MqttAdapterConfig,
+    client: Option<AsyncClient>, // Option because it's set in connect
+    event_loop: Arc<Mutex<Option<EventLoop>>>, // Option and Arc<Mutex> for shared access if needed
+}
+
+impl MqttAdapter {
+    pub fn new(config: MqttAdapterConfig) -> Self {
+        Self {
+            config,
+            client: None,
+            event_loop: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl MessageSystem for MqttAdapter {
+    type ConsumeMessage = OutgoingMessage;
+    type PublishMessage = IncomingMessage;
+    type Error = MqttAdapterError;
+
+    async fn connect(&mut self) -> Result<(), Self::Error> {
+        let random_suffix = nanoid::nanoid!(8);
+        let client_id = format!("{}-{}", self.config.client_id_prefix, random_suffix);
+
+        let mut mqtt_options = MqttOptions::new(client_id, &self.config.broker_address, self.config.broker_port);
+        mqtt_options.set_keep_alive(self.config.keep_alive_interval);
+        // Add other options like TLS, authentication if needed
+
+        tracing::info!(broker = %self.config.broker_address, port = %self.config.broker_port, client_id = %mqtt_options.client_id(), "Connecting to MQTT broker...");
+
+        let (client, event_loop) = AsyncClient::new(mqtt_options, 10); // 10 is the capacity of the event loop queue
+
+        // Subscribe to the consume topic
+        client
+            .subscribe(&self.config.consume_topic, self.config.consume_qos)
+            .await
+            .map_err(|e| MqttAdapterError::SubscriptionFailed(e.to_string()))?;
+
+        tracing::info!(topic = %self.config.consume_topic, qos = ?self.config.consume_qos, "Subscribed to MQTT topic successfully");
+
+        self.client = Some(client);
+        *self.event_loop.lock().await = Some(event_loop); // Store the event loop
+
+        tracing::info!("MQTT client connected and subscribed successfully.");
+        Ok(())
+    }
+
+    async fn consume<F, Fut>(&mut self, mut callback: F) -> Result<(), Self::Error>
+    where
+        F: FnMut(Self::ConsumeMessage) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let event_loop_arc = Arc::clone(&self.event_loop);
+        let mut event_loop_guard = event_loop_arc.lock().await;
+
+        let mut event_loop = match event_loop_guard.take() {
+            Some(el) => el,
+            None => return Err(MqttAdapterError::ConsumeLoopNotRunning),
+        };
+
+        // Drop the guard before entering the loop so it's not held indefinitely
+        drop(event_loop_guard);
+
+        tracing::info!(consume_topic = %self.config.consume_topic, "Starting MQTT event loop for message consumption...");
+
+        loop {
+            match event_loop.poll().await {
+                Ok(event) => {
+                    if let Event::Incoming(Packet::Publish(publish_packet)) = event {
+                        tracing::debug!(topic = %publish_packet.topic, "Received MQTT message");
+                        if publish_packet.topic == self.config.consume_topic {
+                            match serde_json::from_slice::<Self::ConsumeMessage>(&publish_packet.payload) {
+                                Ok(msg) => {
+                                    callback(msg).await;
+                                }
+                                Err(e) => {
+                                    tracing::error!(topic = %publish_packet.topic, error = %e, "Failed to deserialize MQTT message payload");
+                                    // Optionally, could call an error handler callback
+                                }
+                            }
+                        } else {
+                            tracing::trace!(topic = %publish_packet.topic, "Received MQTT message on unhandled topic");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Error in MQTT event loop");
+                    // Depending on the error type, might need to reconnect or can return an error to stop.
+                    // For simplicity, we return an error here.
+                    // Re-store the event_loop if recoverable or if trying to restart
+                    // *self.event_loop.lock().await = Some(event_loop); // Not safe without proper error handling
+                    return Err(MqttAdapterError::MqttConnection(e));
+                }
+            }
+        }
+    }
+
+    async fn publish(&self, message: &Self::PublishMessage) -> Result<(), Self::Error> {
+        let client = self.client.as_ref().ok_or(MqttAdapterError::ConsumeLoopNotRunning)?; // Or a more appropriate error like NotConnected
+
+        tracing::debug!(topic = %self.config.publish_topic, "Attempting to publish MQTT message");
+        let payload = serde_json::to_string(message)?;
+
+        client
+            .publish(
+                &self.config.publish_topic,
+                self.config.publish_qos,
+                false, // retain flag
+                payload.as_bytes(),
+            )
+            .await
+            .map_err(|e| MqttAdapterError::PublishFailed(e.to_string()))?;
+
+        tracing::info!(topic = %self.config.publish_topic, "MQTT Message published successfully.");
+        Ok(())
+    }
+}
+
+// Helper for generating client ID suffix (requires `nanoid` crate to be added to Cargo.toml)
+// Example: `nanoid = "0.4"`
+// For now, this is commented out as nanoid is not yet added.
+// A simpler random suffix can be used if nanoid is not available.
+mod nanoid {
+    use rand::{Rng, distributions::Alphanumeric};
+    pub fn nanoid!(len: usize) -> String {
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(len)
+            .map(char::from)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka_processing::outgoing::{OutgoingMessage, TextMessageData, MessageTarget}; // Reusing for sample data structure
+    use crate::telegram_handler::incoming::{IncomingMessage, IncomingMessageType, TelegramMessageData, MessageSource, FileInfo}; // Reusing
+    use crate::messaging::MessageSystem;
+    use testcontainers_modules::mosquitto::Mosquitto;
+    use testcontainers::clients;
+    use rumqttc::{MqttOptions as RumqttcMqttOptions, AsyncClient as RumqttcAsyncClient, QoS as RumqttcQoS, Event as RumqttcEvent, Packet as RumqttcPacket};
+    use std::time::Duration;
+    use uuid::Uuid;
+    use chrono::Utc;
+    use teloxide::types::Message as TeloxideMessage; // For dummy TelegramMessage
+    use tokio::sync::mpsc as tokio_mpsc; // Explicit import
+
+    // Helper to create a sample IncomingMessage (copied from kafka_adapter tests, ensure consistency or centralize)
+    fn create_sample_incoming_message(text: String) -> IncomingMessage {
+        let dummy_teloxide_msg: TeloxideMessage = serde_json::from_value(serde_json::json!({
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": false, "first_name": "Test"},
+            "text": text,
+        })).unwrap();
+        IncomingMessage {
+            message_type: IncomingMessageType::TelegramMessage(TelegramMessageData {
+                message: dummy_teloxide_msg,
+                downloaded_files: Vec::new(),
+            }),
+            timestamp: Utc::now(),
+            source: MessageSource { platform: "test_mqtt".to_string(), bot_id: Some(123), bot_username: Some("test_bot".to_string()) },
+        }
+    }
+
+    // Helper to create a sample OutgoingMessage (copied from kafka_adapter tests)
+    fn create_sample_outgoing_message(text: String) -> OutgoingMessage {
+        OutgoingMessage {
+            message_type: crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(TextMessageData {
+                text, buttons: None, reply_keyboard: None, parse_mode: None, disable_web_page_preview: None,
+            }),
+            timestamp: Utc::now(),
+            target: MessageTarget { platform: "test_mqtt".to_string(), chat_id: 123, thread_id: None },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mqtt_publish_incoming_message() {
+        let docker = clients::Cli::default();
+        let mosquitto_node = docker.run(Mosquitto::default());
+        let broker_port = mosquitto_node.get_host_port_ipv4(1883);
+        let broker_address = "localhost".to_string();
+
+        let publish_topic = format!("test/publish/{}", Uuid::new_v4());
+        let consume_topic_verifier = publish_topic.clone(); // Verifier subscribes to the same topic
+
+        let adapter_config = MqttAdapterConfig {
+            broker_address: broker_address.clone(),
+            broker_port,
+            client_id_prefix: "test_pub_adapter_".to_string(),
+            consume_topic: "dummy/consume/topic".to_string(), // Not directly used by this adapter's publish
+            publish_topic: publish_topic.clone(),
+            consume_qos: QoS::AtLeastOnce, // Adapter's internal QoS for its consumer
+            publish_qos: QoS::AtLeastOnce, // Adapter's publish QoS
+            keep_alive_interval: Duration::from_secs(5),
+        };
+
+        let mut adapter = MqttAdapter::new(adapter_config);
+        adapter.connect().await.expect("Adapter connect failed for publish test"); // Connect to init client
+
+        let sample_message = create_sample_incoming_message("Hello MQTT from Test!".to_string());
+        adapter.publish(&sample_message).await.expect("Publish failed");
+
+        // Setup a separate rumqttc client to verify the message
+        let verifier_client_id = format!("verifier_{}", Uuid::new_v4());
+        let mut mqtt_options_verifier = RumqttcMqttOptions::new(verifier_client_id, &broker_address, broker_port);
+        mqtt_options_verifier.set_keep_alive(Duration::from_secs(5));
+        let (verifier_client, mut verifier_eventloop) = RumqttcAsyncClient::new(mqtt_options_verifier, 10);
+
+        verifier_client.subscribe(&consume_topic_verifier, RumqttcQoS::AtLeastOnce).await.expect("Verifier subscribe failed");
+
+        let mut received_payload = None;
+        for _ in 0..5 { // Try to poll a few times with timeout
+            match tokio::time::timeout(Duration::from_secs(2), verifier_eventloop.poll()).await {
+                Ok(Ok(RumqttcEvent::Incoming(RumqttcPacket::Publish(publish_packet)))) => {
+                    if publish_packet.topic == consume_topic_verifier {
+                        received_payload = Some(publish_packet.payload);
+                        break;
+                    }
+                }
+                Ok(Ok(_)) => {} // Other events
+                Ok(Err(e)) => {
+                    tracing::error!("Verifier eventloop error: {:?}", e);
+                    break;
+                } // Eventloop error
+                Err(_) => { // Timeout
+                    tracing::warn!("Verifier timeout polling for message");
+                }
+            }
+        }
+
+        assert!(received_payload.is_some(), "Did not receive message on verifier client");
+        let payload_bytes = received_payload.unwrap();
+        let received_deserialized: IncomingMessage = serde_json::from_slice(&payload_bytes).expect("Failed to deserialize consumed message by verifier");
+
+        if let IncomingMessageType::TelegramMessage(tm_data) = received_deserialized.message_type {
+            if let IncomingMessageType::TelegramMessage(sm_data) = sample_message.message_type {
+                 assert_eq!(tm_data.message.text(), sm_data.message.text());
+            } else {
+                panic!("Sample message was not TelegramMessage type");
+            }
+        } else {
+            panic!("Received message was not TelegramMessage type");
+        }
+        assert_eq!(received_deserialized.source.platform, sample_message.source.platform);
+    }
+
+    #[tokio::test]
+    async fn test_mqtt_consume_outgoing_message() {
+        let docker = clients::Cli::default();
+        let mosquitto_node = docker.run(Mosquitto::default());
+        let broker_port = mosquitto_node.get_host_port_ipv4(1883);
+        let broker_address = "localhost".to_string();
+
+        let consume_topic = format!("test/consume/{}", Uuid::new_v4());
+
+        let adapter_config = MqttAdapterConfig {
+            broker_address: broker_address.clone(),
+            broker_port,
+            client_id_prefix: "test_consume_adapter_".to_string(),
+            consume_topic: consume_topic.clone(),
+            publish_topic: "dummy/publish/topic".to_string(), // Not used by this adapter's consume
+            consume_qos: QoS::AtLeastOnce,
+            publish_qos: QoS::AtLeastOnce,
+            keep_alive_interval: Duration::from_secs(5),
+        };
+
+        let mut adapter = MqttAdapter::new(adapter_config);
+        adapter.connect().await.expect("Adapter connect failed for consume test");
+
+        let sample_message = create_sample_outgoing_message("Hello MQTT Adapter, from Test Producer!".to_string());
+
+        // Setup a separate rumqttc client to publish a message
+        let producer_client_id = format!("producer_{}", Uuid::new_v4());
+        let mut mqtt_options_producer = RumqttcMqttOptions::new(producer_client_id, &broker_address, broker_port);
+        mqtt_options_producer.set_keep_alive(Duration::from_secs(5));
+        // Producer client does not need an event loop if it only publishes and doesn't process incoming ACKs explicitly.
+        let (producer_client, _producer_eventloop) = RumqttcAsyncClient::new(mqtt_options_producer, 10);
+
+        let payload = serde_json::to_string(&sample_message).expect("Failed to serialize sample OutgoingMessage");
+        producer_client.publish(&consume_topic, RumqttcQoS::AtLeastOnce, false, payload.as_bytes()).await.expect("Test producer failed to send");
+        tracing::info!("Test message sent to MQTT topic {}", consume_topic);
+
+        let (tx, mut rx) = tokio_mpsc::channel(1);
+
+        tokio::spawn(async move {
+            adapter.consume(move |consumed_message: OutgoingMessage| {
+                let tx_clone = tx.clone();
+                async move {
+                    tx_clone.send(consumed_message).await.expect("Failed to send consumed message via channel");
+                }
+            }).await.expect("Consume loop failed"); // This will run indefinitely unless error
+        });
+
+        let received_message = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("Timeout waiting for consumed message via channel")
+            .expect("Channel closed before message received");
+
+        if let crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(received_text_data) = received_message.message_type {
+             if let crate::kafka_processing::outgoing::OutgoingMessageType::TextMessage(sent_text_data) = sample_message.message_type {
+                assert_eq!(received_text_data.text, sent_text_data.text);
+             } else {
+                panic!("Sample message was not TextMessage type");
+             }
+        } else {
+            panic!("Received message was not TextMessage type");
+        }
+        assert_eq!(received_message.target.chat_id, sample_message.target.chat_id);
+    }
+}


### PR DESCRIPTION
This change refactors the application's messaging infrastructure to support multiple messaging systems beyond Kafka.

Key changes include:

1.  **`MessageSystem` Trait:**
    *   Introduced a new generic trait in `src/messaging.rs` defining a common interface for message consumption and publishing.
    *   The trait supports distinct types for consumed (`ConsumeMessage`) and published (`PublishMessage`) messages, enhancing flexibility.

2.  **`KafkaAdapter`:**
    *   The existing Kafka implementation was refactored into `src/kafka_adapter.rs`.
    *   `KafkaAdapter` now implements the `MessageSystem` trait, handling `OutgoingMessage` for consumption (to Telegram) and `IncomingMessage` for publishing (from Telegram).

3.  **`MqttAdapter`:**
    *   A new `src/mqtt_adapter.rs` was added, providing an MQTT implementation of the `MessageSystem` trait.
    *   It uses the `rumqttc` library and supports the same `OutgoingMessage`/`IncomingMessage` pattern as the Kafka adapter.

4.  **Application Updates:**
    *   `main.rs` was updated to use the `MessageSystem` trait, initially instantiating `KafkaAdapter` by default. The setup for `MqttAdapter` is present but commented out, allowing for easier switching.
    *   Telegram handlers (`src/telegram_handler/`) were updated to use the `MessageSystem` abstraction for publishing messages, removing direct dependency on Kafka producers.

5.  **Testing:**
    *   Comprehensive unit/integration tests were added for both `KafkaAdapter` and `MqttAdapter`.
    *   These tests utilize `testcontainers` to run against real Kafka (via `confluentinc/cp-kafka`) and MQTT (via `eclipse-mosquitto`) brokers in Docker containers, ensuring reliability.
    *   Tests cover connect, publish, and consume operations, including serialization and deserialization of messages.

This refactoring makes the application more extensible, allowing you to choose or add different messaging systems (like MQTT, RabbitMQ, etc.) by implementing the `MessageSystem` trait.