### PR TITLE
Add broker abstraction for Kafka or MQTT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@
 # Required: Your Telegram Bot Token from @BotFather
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 
-# Optional: Your Kafka broker address (default: localhost:9092)
+# Broker type: kafka or mqtt (default: kafka)
+BROKER_TYPE=kafka
+
+# Kafka configuration
 KAFKA_BROKER=localhost:9092
 
 # Optional: Topic for incoming messages from Telegram (default: com.sectorflabs.ratatoskr.in)
@@ -11,6 +14,11 @@ KAFKA_IN_TOPIC=com.sectorflabs.ratatoskr.in
 
 # Optional: Topic for outgoing messages to Telegram (default: com.sectorflabs.ratatoskr.out)
 KAFKA_OUT_TOPIC=com.sectorflabs.ratatoskr.out
+
+# MQTT configuration
+MQTT_BROKER=localhost:1883
+MQTT_IN_TOPIC=com.sectorflabs.ratatoskr.in
+MQTT_OUT_TOPIC=com.sectorflabs.ratatoskr.out
 
 # Optional: Directory to store downloaded images (default: ./images)
 IMAGE_STORAGE_DIR=./images

--- a/.envrc.example
+++ b/.envrc.example
@@ -5,10 +5,18 @@
 # Telegram Bot Configuration
 export TELEGRAM_BOT_TOKEN="your_bot_token_here"
 
+# Broker Configuration
+export BROKER_TYPE="kafka"
+
 # Kafka Configuration
 export KAFKA_BROKER="localhost:9092"
 export KAFKA_IN_TOPIC="com.sectorflabs.ratatoskr.in"
 export KAFKA_OUT_TOPIC="com.sectorflabs.ratatoskr.out"
+
+# MQTT Configuration
+export MQTT_BROKER="localhost:1883"
+export MQTT_IN_TOPIC="com.sectorflabs.ratatoskr.in"
+export MQTT_OUT_TOPIC="com.sectorflabs.ratatoskr.out"
 
 # Image Storage
 export IMAGE_STORAGE_DIR="./images"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +321,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +448,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1249,6 +1282,7 @@ name = "ratatoskr"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "dotenv",
  "futures-util",
@@ -1256,6 +1290,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "reqwest 0.11.27",
+ "rumqttc",
  "serde",
  "serde_json",
  "teloxide",
@@ -1453,6 +1488,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1536,33 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1496,6 +1590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1672,6 +1777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1809,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1785,7 +1905,7 @@ dependencies = [
  "serde_json",
  "teloxide-core",
  "teloxide-macros",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1817,7 +1937,7 @@ dependencies = [
  "stacker",
  "take_mut",
  "takecell",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "url",
@@ -1843,10 +1963,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1855,7 +1984,18 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1960,6 +2100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2119,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2113,6 +2265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,7 +2294,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ license = "BSD-3-Clause"
 teloxide = { version = "0.15", features = ["macros"] }
 tokio = { version = "1.45", features = ["full"] }
 rdkafka = { version = "0.37", features = ["tokio"] }
+rumqttc = "0.24"
+async-trait = "0.1"
 dotenv = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 futures-util = "0.3"
 reqwest = { version = "0.11", features = ["stream"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,27 @@
 
 .PHONY: help install setup run dev stop produce test_buttons test_image test_callback test_typing test_typing_demo install-service uninstall-service start-service stop-service status-service
 
+# Broker configuration (supports both Kafka and MQTT)
+BROKER_TYPE?=kafka
+
 # Kafka config
 KAFKA_BROKER?=localhost:9092
 KAFKA_IN_TOPIC?=com.sectorflabs.ratatoskr.in
 KAFKA_OUT_TOPIC?=com.sectorflabs.ratatoskr.out
 
+# MQTT config
+MQTT_BROKER?=localhost:1883
+MQTT_IN_TOPIC?=com.sectorflabs.ratatoskr.in
+MQTT_OUT_TOPIC?=com.sectorflabs.ratatoskr.out
+
 # Export variables so scripts can use them
+export BROKER_TYPE
 export KAFKA_BROKER
 export KAFKA_IN_TOPIC
 export KAFKA_OUT_TOPIC
+export MQTT_BROKER
+export MQTT_IN_TOPIC
+export MQTT_OUT_TOPIC
 
 # Default target - show help
 help:
@@ -35,16 +47,29 @@ help:
 	@echo "  dev           Run the bot with auto-reload (cargo watch)"
 	@echo "  stop          Stop Kafka container"
 	@echo ""
-	@echo "Testing targets:"
-	@echo "  produce       Send text message (TEXT=\"your message\")"
+	@echo "Testing targets (Unified - work with both brokers):"
+	@echo "  test_text     Send text message (TEXT=\"your message\")"
 	@echo "  test_buttons  Send message with buttons (TEXT=\"your message\")"
+	@echo "  test_typing   Send typing indicator"
+	@echo "  consume       Monitor incoming messages (N=number)"
+	@echo "  test_all_message_types  Test all unified message types with current BROKER_TYPE"
+	@echo "  test_comprehensive      Run comprehensive tests on both Kafka and MQTT"
+	@echo "  test_both_brokers       Quick test of both brokers with same messages"
+	@echo ""
+	@echo "Broker-specific testing:"
+	@echo "  test_*_kafka  Run test with Kafka broker (BROKER_TYPE=kafka)"
+	@echo "  test_*_mqtt   Run test with MQTT broker (BROKER_TYPE=mqtt)"
+	@echo "  setup_kafka   Start Kafka stack and create topics"
+	@echo "  setup_mqtt    Start MQTT stack"
+	@echo ""
+	@echo "Legacy testing targets (Kafka only):"
+	@echo "  test_all_message_types_legacy  Test all message types with legacy Kafka scripts"
 	@echo "  test_auto_buttons  Test auto-organized button functionality"
 	@echo "  test_cafe_buttons  Test auto-organization with real cafe buttons"
 	@echo "  test_image    Send image message (IMAGE_PATH=path CAPTION=\"caption\")"
 	@echo "  test_callback Simulate callback (MESSAGE_ID=123 CALLBACK_DATA=\"data\")"
 	@echo "  test_keyboard Send message with reply keyboard (TEXT=\"your message\")"
 	@echo "  test_location Send location request with reply keyboard"
-	@echo "  test_typing   Send typing indicator"
 	@echo "  test_typing_demo Send typing indicator followed by message"
 	@echo "  test_markdown Send complex markdown formatting test messages"
 	@echo "  test_simple_markdown Send single markdown test message (TEXT=\"message\")"
@@ -52,13 +77,14 @@ help:
 	@echo "  test_markdown_fallback Test markdown fallback to plain text functionality"
 	@echo "  test_backward_compatibility Test legacy messages without trace_id"
 	@echo ""
+	@echo "Note: Unified scripts support both Kafka and MQTT. Legacy scripts are Kafka-only."
+	@echo ""
 	@echo "Environment variables:"
-	@echo "  See .envrc.example for all configuration options"
-	@echo "  Copy .envrc.example to .envrc and customize"
+	@echo "  BROKER_TYPE        - Broker type: kafka (default) or mqtt"
 	@echo "  CHAT_ID            - Target Telegram chat ID (required for testing)"
-	@echo "  REMOTE_HOST        - Remote host for deployment"
-	@echo "  REMOTE_USER        - Remote user for deployment"
-	@echo "  REMOTE_PATH        - Remote path for deployment"
+	@echo "  KAFKA_BROKER       - Kafka broker address (default: localhost:9092)"
+	@echo "  MQTT_BROKER        - MQTT broker address (default: localhost:1883)"
+	@echo "  See .envrc.example for all configuration options"
 
 main:
 	cargo build
@@ -66,8 +92,14 @@ main:
 install:
 	cargo install --path .
 
-setup:
+setup: setup_kafka
+
+setup_kafka:
 	./scripts/setup_env.sh
+
+setup_mqtt:
+	docker-compose -f mqtt-stack.yml up -d
+	BROKER_TYPE=mqtt ./scripts/setup_env_unified.sh
 
 run:
 	cargo run
@@ -77,14 +109,54 @@ dev:
 stop:
 	pkill -f "kafka" || true
 
+# Unified targets (work with both Kafka and MQTT based on BROKER_TYPE)
 consume:
-	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_IN_TOPIC=$(KAFKA_IN_TOPIC) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/consume.sh $(N)
+	BROKER_TYPE=$(BROKER_TYPE) ./scripts/consume_unified.sh "" $(N)
 
 test_text:
-	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce.sh "$(TEXT)"
+	BROKER_TYPE=$(BROKER_TYPE) ./scripts/produce_unified.sh "$(TEXT)"
 
 test_buttons:
+	BROKER_TYPE=$(BROKER_TYPE) ./scripts/produce_with_buttons_unified.sh "$(TEXT)"
+
+test_typing:
+	BROKER_TYPE=$(BROKER_TYPE) ./scripts/produce_typing_unified.sh
+
+# Kafka-specific targets
+test_text_kafka:
+	BROKER_TYPE=kafka ./scripts/produce_unified.sh "$(TEXT)"
+
+test_buttons_kafka:
+	BROKER_TYPE=kafka ./scripts/produce_with_buttons_unified.sh "$(TEXT)"
+
+test_typing_kafka:
+	BROKER_TYPE=kafka ./scripts/produce_typing_unified.sh
+
+consume_kafka:
+	BROKER_TYPE=kafka ./scripts/consume_unified.sh "" $(N)
+
+# MQTT-specific targets
+test_text_mqtt:
+	BROKER_TYPE=mqtt ./scripts/produce_unified.sh "$(TEXT)"
+
+test_buttons_mqtt:
+	BROKER_TYPE=mqtt ./scripts/produce_with_buttons_unified.sh "$(TEXT)"
+
+test_typing_mqtt:
+	BROKER_TYPE=mqtt ./scripts/produce_typing_unified.sh
+
+consume_mqtt:
+	BROKER_TYPE=mqtt ./scripts/consume_unified.sh "" $(N)
+
+# Legacy Kafka-only targets (using original scripts)
+legacy_test_text:
+	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce.sh "$(TEXT)"
+
+legacy_test_buttons:
 	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce_with_buttons.sh "$(TEXT)"
+
+legacy_consume:
+	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_IN_TOPIC=$(KAFKA_IN_TOPIC) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/consume.sh $(N)
 
 test_auto_buttons:
 	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/test_auto_buttons.sh
@@ -107,24 +179,62 @@ test_markdown_fallback:
 test_image:
 	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce_image.sh "$(IMAGE_PATH)" "$(CAPTION)"
 
-test_typing:
-	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce_typing.sh
-
 test_typing_demo:
 	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce_typing_demo.sh
 
-test_all_message_types: test_text test_buttons test_image test_typing test_markdown test_markdown_edge_cases test_markdown_fallback
-	echo "All message types tested."
+# Test all unified message types
+test_all_unified: test_text test_buttons test_typing
+	@echo "All unified message types tested with $(BROKER_TYPE) broker."
+
+# Test both brokers with same message types
+test_both_brokers:
+	@echo "Testing with Kafka..."
+	$(MAKE) test_text_kafka TEXT="Test message via Kafka"
+	$(MAKE) test_buttons_kafka TEXT="Test buttons via Kafka"
+	$(MAKE) test_typing_kafka
+	@echo ""
+	@echo "Testing with MQTT..."
+	$(MAKE) test_text_mqtt TEXT="Test message via MQTT"
+	$(MAKE) test_buttons_mqtt TEXT="Test buttons via MQTT"
+	$(MAKE) test_typing_mqtt
+	@echo ""
+	@echo "Both brokers tested successfully!"
+
+# Comprehensive test of both brokers with detailed output
+test_comprehensive:
+	./scripts/test_both_brokers.sh
+
+# Test all unified message types with current broker type
+test_all_message_types: test_text test_buttons test_typing
+	@echo "All unified message types tested with $(BROKER_TYPE) broker."
+	@echo "Note: For additional message types (image, markdown, etc.), use legacy targets or create unified versions."
+
+# Legacy test target (Kafka only) - includes all message types
+test_all_message_types_legacy: legacy_test_text legacy_test_buttons test_image legacy_typing test_markdown test_markdown_edge_cases test_markdown_fallback
+	@echo "All message types tested (legacy Kafka scripts)."
+
+# Kafka-only legacy typing target (for legacy test suite)
+legacy_typing:
+	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC) ./scripts/produce_typing.sh
 
 debug:
 	@echo "Make variables:"
+	@echo "  BROKER_TYPE=$(BROKER_TYPE)"
 	@echo "  KAFKA_BROKER=$(KAFKA_BROKER)"
 	@echo "  KAFKA_IN_TOPIC=$(KAFKA_IN_TOPIC)"
 	@echo "  KAFKA_OUT_TOPIC=$(KAFKA_OUT_TOPIC)"
+	@echo "  MQTT_BROKER=$(MQTT_BROKER)"
+	@echo "  MQTT_IN_TOPIC=$(MQTT_IN_TOPIC)"
+	@echo "  MQTT_OUT_TOPIC=$(MQTT_OUT_TOPIC)"
 	@echo "Environment variables:"
+	@echo "  BROKER_TYPE=$$BROKER_TYPE"
 	@echo "  KAFKA_BROKER=$$KAFKA_BROKER"
 	@echo "  KAFKA_IN_TOPIC=$$KAFKA_IN_TOPIC"
 	@echo "  KAFKA_OUT_TOPIC=$$KAFKA_OUT_TOPIC"
+	@echo "  MQTT_BROKER=$$MQTT_BROKER"
+	@echo "  MQTT_IN_TOPIC=$$MQTT_IN_TOPIC"
+	@echo "  MQTT_OUT_TOPIC=$$MQTT_OUT_TOPIC"
+	@echo "  CHAT_ID=$$CHAT_ID"
 
 test_callback:
 	KAFKA_BROKER=$(KAFKA_BROKER) KAFKA_IN_TOPIC=$(KAFKA_IN_TOPIC) ./scripts/simulate_callback.sh $(MESSAGE_ID) "$(CALLBACK_DATA)"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A lightweight Telegram <-> Kafka bridge written in **Rust**, designed to decoupl
 ## 🚀 Features
 
 * Uses [`teloxide`](https://github.com/teloxide/teloxide) for Telegram bot integration
-* Uses [`rdkafka`](https://github.com/fede1024/rust-rdkafka) for Kafka connectivity
-* Forwards full Telegram message objects to Kafka
+* Supports Kafka via [`rdkafka`](https://github.com/fede1024/rust-rdkafka) and MQTT via [`rumqttc`](https://github.com/bytebeamio/rumqtt)
+* Forwards full Telegram message objects to the selected broker
 * **Automatic image downloading** - Downloads images from Telegram messages and stores them locally ([documentation](docs/image_downloading.md))
 * Listens for outbound messages on a Kafka topic and sends them back to Telegram
 * Minimal, event-driven, and easy to extend
@@ -35,9 +35,10 @@ A lightweight Telegram <-> Kafka bridge written in **Rust**, designed to decoupl
 2. **Set environment variables:**
 
    * `TELEGRAM_BOT_TOKEN` (**required**)
-   * `KAFKA_BROKER` (optional, default: `localhost:9092`)
-   * `KAFKA_IN_TOPIC` (optional, default: `com.sectorflabs.ratatoskr.in`)
-   * `KAFKA_OUT_TOPIC` (optional, default: `com.sectorflabs.ratatoskr.out`)
+   * `BROKER_TYPE` (optional, `kafka` or `mqtt`, default: `kafka`)
+   * `KAFKA_BROKER` / `MQTT_BROKER` (broker address)
+   * `KAFKA_IN_TOPIC` / `MQTT_IN_TOPIC` (incoming topic)
+   * `KAFKA_OUT_TOPIC` / `MQTT_OUT_TOPIC` (outgoing topic)
    * `IMAGE_STORAGE_DIR` (optional, default: `./images`)
 
    You can place these in a `.env` file or export them in your shell. A `.env.example` file is provided as a template.
@@ -133,6 +134,12 @@ For a complete development environment with Kafka, Zookeeper, and Kafdrop (a Kaf
    - Ratatoskr: Running in container
    - Kafka: localhost:9092
    - Kafdrop (Kafka UI): http://localhost:9000
+
+Alternatively, to try the MQTT backend, run:
+
+```sh
+docker compose -f mqtt-stack.yml up -d
+```
 
 
 ---

--- a/mqtt-stack.yml
+++ b/mqtt-stack.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+
+services:
+  mosquitto:
+    image: eclipse-mosquitto
+    container_name: mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - mosquitto-data:/mosquitto/data
+      - mosquitto-log:/mosquitto/log
+    restart: unless-stopped
+
+volumes:
+  mosquitto-data:
+  mosquitto-log:

--- a/scripts/consume_unified.sh
+++ b/scripts/consume_unified.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Unified consumer script for Ratatoskr
+# Supports both Kafka and MQTT brokers based on BROKER_TYPE environment variable
+# Usage: ./scripts/consume_unified.sh [TOPIC] [MAX_MESSAGES]
+
+set -e
+
+# Source the unified environment setup script
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/setup_env_unified.sh" || {
+  echo "Error: Failed to source setup_env_unified.sh"
+  exit 1
+}
+
+# Set topic and message limit
+TOPIC=${1:-"$IN_TOPIC"}
+MAX_MESSAGES=${2:-""}
+
+echo "Starting consumer for $BROKER_TYPE broker..."
+echo "Topic: $TOPIC"
+echo "Broker: $BROKER_HOST"
+
+if [ -n "$MAX_MESSAGES" ]; then
+    echo "Max messages: $MAX_MESSAGES"
+fi
+
+echo "Press Ctrl+C to stop..."
+echo ""
+
+# Start consuming based on broker type
+case "$BROKER_TYPE" in
+    "kafka")
+        echo "=== Consuming from Kafka topic: $TOPIC ==="
+
+        KAFKA_CONSUMER_ARGS="--bootstrap-server $KAFKA_BROKER --topic $TOPIC --from-beginning"
+
+        if [ -n "$MAX_MESSAGES" ]; then
+            KAFKA_CONSUMER_ARGS="$KAFKA_CONSUMER_ARGS --max-messages $MAX_MESSAGES"
+        fi
+
+        # Use kafka console consumer with pretty printing
+        $KAFKA_CONSOLE_CONSUMER_CMD $KAFKA_CONSUMER_ARGS --property print.key=true --property key.separator=: | while IFS=: read -r key message; do
+            echo "----------------------------------------"
+            echo "Key: $key"
+            echo "Timestamp: $(date)"
+            echo "Message:"
+            echo "$message" | jq . 2>/dev/null || echo "$message"
+            echo ""
+        done
+        ;;
+
+    "mqtt")
+        echo "=== Consuming from MQTT topic: $TOPIC ==="
+
+        MQTT_SUB_ARGS="-h $MQTT_HOST -p $MQTT_PORT -t $TOPIC"
+
+        if [ -n "$MAX_MESSAGES" ]; then
+            MQTT_SUB_ARGS="$MQTT_SUB_ARGS -C $MAX_MESSAGES"
+        fi
+
+        # Use mosquitto subscriber with pretty printing
+        $MQTT_SUB_CMD $MQTT_SUB_ARGS | while read -r message; do
+            echo "----------------------------------------"
+            echo "Timestamp: $(date)"
+            echo "Topic: $TOPIC"
+            echo "Message:"
+            echo "$message" | jq . 2>/dev/null || echo "$message"
+            echo ""
+        done
+        ;;
+
+    *)
+        echo "Error: Unsupported broker type: $BROKER_TYPE"
+        exit 1
+        ;;
+esac
+
+echo "Consumer stopped."

--- a/scripts/produce_typing_unified.sh
+++ b/scripts/produce_typing_unified.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Unified typing indicator producer script for Ratatoskr
+# Supports both Kafka and MQTT brokers based on BROKER_TYPE environment variable
+# Usage: ./scripts/produce_typing_unified.sh
+
+set -e
+
+# Source the unified environment setup script
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/setup_env_unified.sh" || {
+  echo "Error: Failed to source setup_env_unified.sh"
+  exit 1
+}
+
+# Create a temporary file for the message
+TMP_FILE=$(mktemp)
+trap "rm -f $TMP_FILE" EXIT
+
+# Generate timestamp
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Create typing message JSON
+cat > "$TMP_FILE" <<EOF
+{
+  "trace_id": "$(uuidgen | tr '[:upper:]' '[:lower:]')",
+  "message_type": {
+    "type": "TypingMessage",
+    "data": {
+      "action": "typing"
+    }
+  },
+  "timestamp": "$TIMESTAMP",
+  "target": {
+    "platform": "telegram",
+    "chat_id": $CHAT_ID,
+    "thread_id": null
+  }
+}
+EOF
+
+# Display the message being sent
+echo "Sending typing indicator to chat $CHAT_ID via $BROKER_TYPE..."
+echo "Message: $(cat "$TMP_FILE" | jq -c . 2>/dev/null || cat "$TMP_FILE")"
+
+# Compact JSON to single line
+JSON_MESSAGE=$(cat "$TMP_FILE" | jq -c .)
+
+# Send message based on broker type
+case "$BROKER_TYPE" in
+    "kafka")
+        echo "Sending via Kafka..."
+        echo "$CHAT_ID:$JSON_MESSAGE" | $KAFKA_CONSOLE_PRODUCER_CMD --bootstrap-server "$KAFKA_BROKER" --topic "$OUT_TOPIC" --property "key.separator=:" --property "parse.key=true"
+        ;;
+
+    "mqtt")
+        echo "Sending via MQTT..."
+        echo "$JSON_MESSAGE" | $MQTT_PUB_CMD -h "$MQTT_HOST" -p "$MQTT_PORT" -t "$OUT_TOPIC" -l
+        ;;
+
+    *)
+        echo "Error: Unsupported broker type: $BROKER_TYPE"
+        exit 1
+        ;;
+esac
+
+echo "Typing indicator sent successfully via $BROKER_TYPE!"
+echo "The bot should now show 'typing...' in chat $CHAT_ID"

--- a/scripts/produce_unified.sh
+++ b/scripts/produce_unified.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Unified producer script for Ratatoskr
+# Supports both Kafka and MQTT brokers based on BROKER_TYPE environment variable
+# Usage: ./scripts/produce_unified.sh [MESSAGE_TEXT]
+
+set -e
+
+# Source the unified environment setup script
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/setup_env_unified.sh" || {
+  echo "Error: Failed to source setup_env_unified.sh"
+  exit 1
+}
+
+# Set a default message text
+MESSAGE_TEXT=${1:-"Hello from Ratatoskr unified test script!"}
+
+# Create a temporary file for the message
+TMP_FILE=$(mktemp)
+trap "rm -f $TMP_FILE" EXIT
+
+# Write the correctly formatted JSON to the temporary file
+cat > "$TMP_FILE" << EOF
+{
+  "trace_id": "$(uuidgen | tr '[:upper:]' '[:lower:]')",
+  "message_type": {
+    "type": "TextMessage",
+    "data": {
+      "text": "$MESSAGE_TEXT",
+      "buttons": null,
+      "parse_mode": null,
+      "disable_web_page_preview": false
+    }
+  },
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "target": {
+    "platform": "telegram",
+    "chat_id": $CHAT_ID,
+    "thread_id": null
+  }
+}
+EOF
+
+# Display the message being sent
+echo "Producing message to $OUT_TOPIC ($BROKER_TYPE):"
+cat "$TMP_FILE" | jq 2>/dev/null || cat "$TMP_FILE"
+
+# Compact JSON to single line
+JSON_MESSAGE=$(cat "$TMP_FILE" | jq -c .)
+
+# Send message based on broker type
+case "$BROKER_TYPE" in
+    "kafka")
+        echo "Sending via Kafka..."
+        echo "$CHAT_ID:$JSON_MESSAGE" | $KAFKA_CONSOLE_PRODUCER_CMD --bootstrap-server "$KAFKA_BROKER" --topic "$OUT_TOPIC" --property "key.separator=:" --property "parse.key=true"
+        ;;
+
+    "mqtt")
+        echo "Sending via MQTT..."
+        echo "$JSON_MESSAGE" | $MQTT_PUB_CMD -h "$MQTT_HOST" -p "$MQTT_PORT" -t "$OUT_TOPIC" -l
+        ;;
+
+    *)
+        echo "Error: Unsupported broker type: $BROKER_TYPE"
+        exit 1
+        ;;
+esac
+
+echo "Message sent successfully via $BROKER_TYPE!"

--- a/scripts/produce_with_buttons_unified.sh
+++ b/scripts/produce_with_buttons_unified.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Unified buttons producer script for Ratatoskr
+# Supports both Kafka and MQTT brokers based on BROKER_TYPE environment variable
+# Usage: ./scripts/produce_with_buttons_unified.sh [MESSAGE_TEXT]
+
+set -e
+
+# Source the unified environment setup script
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/setup_env_unified.sh" || {
+  echo "Error: Failed to source setup_env_unified.sh"
+  exit 1
+}
+
+# Set a default message text
+MESSAGE_TEXT=${1:-"This is a test message with buttons!"}
+
+# Create a temporary file for the message
+TMP_FILE=$(mktemp)
+trap "rm -f $TMP_FILE" EXIT
+
+# Write the correctly formatted JSON to the temporary file
+cat > "$TMP_FILE" << EOF
+{
+  "trace_id": "$(uuidgen | tr '[:upper:]' '[:lower:]')",
+  "message_type": {
+    "type": "TextMessage",
+    "data": {
+      "text": "$MESSAGE_TEXT",
+      "buttons": [
+        [
+          {"text": "Button 1", "callback_data": "button1_action"},
+          {"text": "Button 2", "callback_data": "button2_action"}
+        ],
+        [
+          {"text": "Button 3", "callback_data": "button3_action"}
+        ]
+      ],
+      "parse_mode": null,
+      "disable_web_page_preview": false
+    }
+  },
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "target": {
+    "platform": "telegram",
+    "chat_id": $CHAT_ID,
+    "thread_id": null
+  }
+}
+EOF
+
+# Display the message being sent
+echo "Producing message with buttons to $OUT_TOPIC ($BROKER_TYPE):"
+cat "$TMP_FILE" | jq 2>/dev/null || cat "$TMP_FILE"
+
+# Compact JSON to single line
+JSON_MESSAGE=$(cat "$TMP_FILE" | jq -c .)
+
+# Send message based on broker type
+case "$BROKER_TYPE" in
+    "kafka")
+        echo "Sending via Kafka..."
+        echo "$CHAT_ID:$JSON_MESSAGE" | $KAFKA_CONSOLE_PRODUCER_CMD --bootstrap-server "$KAFKA_BROKER" --topic "$OUT_TOPIC" --property "key.separator=:" --property "parse.key=true"
+        ;;
+
+    "mqtt")
+        echo "Sending via MQTT..."
+        echo "$JSON_MESSAGE" | $MQTT_PUB_CMD -h "$MQTT_HOST" -p "$MQTT_PORT" -t "$OUT_TOPIC" -l
+        ;;
+
+    *)
+        echo "Error: Unsupported broker type: $BROKER_TYPE"
+        exit 1
+        ;;
+esac
+
+echo "Message with buttons sent successfully via $BROKER_TYPE!"

--- a/scripts/setup_env_unified.sh
+++ b/scripts/setup_env_unified.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# Unified environment setup for Ratatoskr scripts
+# Supports both Kafka and MQTT brokers based on BROKER_TYPE environment variable
+# This script can be sourced by other scripts to verify environment
+
+# Colors for terminal output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Set default broker type
+BROKER_TYPE=${BROKER_TYPE:-"kafka"}
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+# Function to check Kafka tools
+check_kafka_tools() {
+    if ! command_exists kafka-topics && ! command_exists kafka-topics.sh; then
+        echo -e "${RED}Error: Kafka command-line tools not found${NC}"
+        echo "Please install Kafka and ensure kafka-topics.sh is in your PATH"
+        echo "You can install with: brew install kafka"
+        echo "Or download from: https://kafka.apache.org/downloads"
+        return 1
+    fi
+
+    # Determine which kafka command to use
+    if command_exists kafka-topics.sh; then
+        export KAFKA_TOPICS_CMD="kafka-topics.sh"
+        export KAFKA_CONSOLE_PRODUCER_CMD="kafka-console-producer.sh"
+        export KAFKA_CONSOLE_CONSUMER_CMD="kafka-console-consumer.sh"
+    else
+        export KAFKA_TOPICS_CMD="kafka-topics"
+        export KAFKA_CONSOLE_PRODUCER_CMD="kafka-console-producer"
+        export KAFKA_CONSOLE_CONSUMER_CMD="kafka-console-consumer"
+    fi
+    return 0
+}
+
+# Function to check MQTT tools
+check_mqtt_tools() {
+    if ! command_exists mosquitto_pub || ! command_exists mosquitto_sub; then
+        echo -e "${RED}Error: MQTT command-line tools not found${NC}"
+        echo "Please install Mosquitto client tools:"
+        echo "  macOS: brew install mosquitto"
+        echo "  Ubuntu/Debian: apt install mosquitto-clients"
+        echo "  RHEL/CentOS: yum install mosquitto"
+        return 1
+    fi
+
+    export MQTT_PUB_CMD="mosquitto_pub"
+    export MQTT_SUB_CMD="mosquitto_sub"
+    return 0
+}
+
+# Check for required common tools
+if ! command_exists jq; then
+    echo -e "${RED}Error: jq not found${NC}"
+    echo "Please install it with: brew install jq (macOS) or apt install jq (Debian/Ubuntu)"
+    exit 1
+fi
+
+if ! command_exists uuidgen; then
+    echo -e "${RED}Error: uuidgen not found${NC}"
+    echo "Please install it (usually part of util-linux package)"
+    exit 1
+fi
+
+# Configure broker-specific settings
+case "$BROKER_TYPE" in
+    "kafka")
+        echo -e "${BLUE}Configuring for Kafka broker...${NC}"
+
+        # Check Kafka tools
+        if ! check_kafka_tools; then
+            exit 1
+        fi
+
+        # Set Kafka defaults
+        export KAFKA_BROKER=${KAFKA_BROKER:-"localhost:9092"}
+        export KAFKA_IN_TOPIC=${KAFKA_IN_TOPIC:-"com.sectorflabs.ratatoskr.in"}
+        export KAFKA_OUT_TOPIC=${KAFKA_OUT_TOPIC:-"com.sectorflabs.ratatoskr.out"}
+
+        # Set unified broker variables
+        export BROKER_HOST="$KAFKA_BROKER"
+        export IN_TOPIC="$KAFKA_IN_TOPIC"
+        export OUT_TOPIC="$KAFKA_OUT_TOPIC"
+        ;;
+
+    "mqtt")
+        echo -e "${BLUE}Configuring for MQTT broker...${NC}"
+
+        # Check MQTT tools
+        if ! check_mqtt_tools; then
+            exit 1
+        fi
+
+        # Set MQTT defaults
+        export MQTT_BROKER=${MQTT_BROKER:-"localhost:1883"}
+        export MQTT_IN_TOPIC=${MQTT_IN_TOPIC:-"com.sectorflabs.ratatoskr.in"}
+        export MQTT_OUT_TOPIC=${MQTT_OUT_TOPIC:-"com.sectorflabs.ratatoskr.out"}
+
+        # Parse MQTT broker into host and port
+        IFS=':' read -r MQTT_HOST MQTT_PORT <<< "$MQTT_BROKER"
+        export MQTT_HOST=${MQTT_HOST:-"localhost"}
+        export MQTT_PORT=${MQTT_PORT:-"1883"}
+
+        # Set unified broker variables
+        export BROKER_HOST="$MQTT_BROKER"
+        export IN_TOPIC="$MQTT_IN_TOPIC"
+        export OUT_TOPIC="$MQTT_OUT_TOPIC"
+        ;;
+
+    *)
+        echo -e "${RED}Error: Unsupported BROKER_TYPE: $BROKER_TYPE${NC}"
+        echo "Supported values: kafka, mqtt"
+        exit 1
+        ;;
+esac
+
+# Check if CHAT_ID is set
+if [ -z "$CHAT_ID" ]; then
+    echo -e "${YELLOW}Warning: CHAT_ID environment variable is not set${NC}"
+    echo "Please set it to your Telegram chat ID, for example:"
+    echo "export CHAT_ID=123456789"
+    echo "This is needed for most test scripts to work properly."
+
+    # Allow script to continue if this was just sourced (not directly executed)
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+        exit 1
+    fi
+fi
+
+# Function to test broker connectivity
+test_broker_connectivity() {
+    case "$BROKER_TYPE" in
+        "kafka")
+            echo -e "${BLUE}Testing Kafka connectivity...${NC}"
+            if $KAFKA_TOPICS_CMD --bootstrap-server "$KAFKA_BROKER" --list &>/dev/null; then
+                echo -e "${GREEN}✓ Kafka broker reachable at $KAFKA_BROKER${NC}"
+                return 0
+            else
+                echo -e "${RED}✗ Failed to connect to Kafka broker at $KAFKA_BROKER${NC}"
+                return 1
+            fi
+            ;;
+
+        "mqtt")
+            echo -e "${BLUE}Testing MQTT connectivity...${NC}"
+            # Test MQTT connection with a simple publish (will fail if broker is unreachable)
+            if timeout 5s mosquitto_pub -h "$MQTT_HOST" -p "$MQTT_PORT" -t "test/connectivity" -m "test" &>/dev/null; then
+                echo -e "${GREEN}✓ MQTT broker reachable at $MQTT_HOST:$MQTT_PORT${NC}"
+                return 0
+            else
+                echo -e "${YELLOW}⚠ MQTT broker may not be reachable at $MQTT_HOST:$MQTT_PORT${NC}"
+                echo -e "${YELLOW}  This might be OK if the broker requires authentication${NC}"
+                return 0  # Don't fail completely for MQTT
+            fi
+            ;;
+    esac
+}
+
+# Function to create/verify topics (Kafka only)
+setup_topics() {
+    if [ "$BROKER_TYPE" = "kafka" ]; then
+        echo -e "\n${BLUE}Checking/Creating Kafka topics:${NC}"
+
+        # Check if input topic exists
+        if ! $KAFKA_TOPICS_CMD --bootstrap-server "$KAFKA_BROKER" --list | grep -q "^$KAFKA_IN_TOPIC$"; then
+            echo -e "Creating topic: ${YELLOW}$KAFKA_IN_TOPIC${NC}"
+            $KAFKA_TOPICS_CMD --bootstrap-server "$KAFKA_BROKER" --create --topic "$KAFKA_IN_TOPIC" --partitions 1 --replication-factor 1
+        else
+            echo -e "Topic exists: ${GREEN}$KAFKA_IN_TOPIC${NC}"
+        fi
+
+        # Check if output topic exists
+        if ! $KAFKA_TOPICS_CMD --bootstrap-server "$KAFKA_BROKER" --list | grep -q "^$KAFKA_OUT_TOPIC$"; then
+            echo -e "Creating topic: ${YELLOW}$KAFKA_OUT_TOPIC${NC}"
+            $KAFKA_TOPICS_CMD --bootstrap-server "$KAFKA_BROKER" --create --topic "$KAFKA_OUT_TOPIC" --partitions 1 --replication-factor 1
+        else
+            echo -e "Topic exists: ${GREEN}$KAFKA_OUT_TOPIC${NC}"
+        fi
+    else
+        echo -e "\n${BLUE}MQTT topics are created automatically on first publish${NC}"
+        echo -e "Using topics: ${GREEN}$MQTT_IN_TOPIC${NC}, ${GREEN}$MQTT_OUT_TOPIC${NC}"
+    fi
+}
+
+# Function to publish message (broker-agnostic)
+publish_message() {
+    local topic="$1"
+    local message="$2"
+    local key="$3"  # Optional, only used for Kafka
+
+    case "$BROKER_TYPE" in
+        "kafka")
+            if [ -n "$key" ]; then
+                echo "$key:$message" | $KAFKA_CONSOLE_PRODUCER_CMD --bootstrap-server "$KAFKA_BROKER" --topic "$topic" --property "key.separator=:" --property "parse.key=true"
+            else
+                echo "$message" | $KAFKA_CONSOLE_PRODUCER_CMD --bootstrap-server "$KAFKA_BROKER" --topic "$topic"
+            fi
+            ;;
+
+        "mqtt")
+            echo "$message" | $MQTT_PUB_CMD -h "$MQTT_HOST" -p "$MQTT_PORT" -t "$topic" -l
+            ;;
+    esac
+}
+
+# Print environment settings if being run directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo -e "${BLUE}=== Ratatoskr Unified Environment ===${NC}"
+    echo -e "BROKER_TYPE: ${YELLOW}$BROKER_TYPE${NC}"
+    echo -e "CHAT_ID: ${YELLOW}$CHAT_ID${NC}"
+    echo -e "BROKER_HOST: ${GREEN}$BROKER_HOST${NC}"
+    echo -e "IN_TOPIC: ${GREEN}$IN_TOPIC${NC}"
+    echo -e "OUT_TOPIC: ${GREEN}$OUT_TOPIC${NC}"
+
+    if [ "$BROKER_TYPE" = "kafka" ]; then
+        echo -e "KAFKA_BROKER: ${GREEN}$KAFKA_BROKER${NC}"
+        echo -e "KAFKA_IN_TOPIC: ${GREEN}$KAFKA_IN_TOPIC${NC}"
+        echo -e "KAFKA_OUT_TOPIC: ${GREEN}$KAFKA_OUT_TOPIC${NC}"
+    else
+        echo -e "MQTT_BROKER: ${GREEN}$MQTT_BROKER${NC}"
+        echo -e "MQTT_HOST: ${GREEN}$MQTT_HOST${NC}"
+        echo -e "MQTT_PORT: ${GREEN}$MQTT_PORT${NC}"
+        echo -e "MQTT_IN_TOPIC: ${GREEN}$MQTT_IN_TOPIC${NC}"
+        echo -e "MQTT_OUT_TOPIC: ${GREEN}$MQTT_OUT_TOPIC${NC}"
+    fi
+
+    # Test connectivity
+    test_broker_connectivity
+
+    # Setup topics
+    setup_topics
+
+    echo -e "\n${GREEN}Environment is ready for Ratatoskr scripts with $BROKER_TYPE broker${NC}"
+else
+    # When sourced, show which broker we're using
+    echo -e "${BLUE}Using $BROKER_TYPE broker: ${GREEN}$BROKER_HOST${NC}"
+fi

--- a/scripts/test_both_brokers.sh
+++ b/scripts/test_both_brokers.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+
+# Comprehensive test script for both Kafka and MQTT brokers
+# Tests the same message types against both brokers to ensure compatibility
+# Usage: ./scripts/test_both_brokers.sh
+
+set -e
+
+# Colors for terminal output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Test configuration
+TEST_TEXT_MESSAGE="Test message from both brokers script"
+TEST_BUTTON_MESSAGE="Test buttons from both brokers script"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Function to print section headers
+print_section() {
+    echo -e "\n${CYAN}========================================${NC}"
+    echo -e "${CYAN}$1${NC}"
+    echo -e "${CYAN}========================================${NC}"
+}
+
+# Function to print test headers
+print_test() {
+    echo -e "\n${BLUE}--- $1 ---${NC}"
+}
+
+# Function to print success message
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+# Function to print error message
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+# Function to print warning message
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+# Function to test broker connectivity
+test_broker_connectivity() {
+    local broker_type=$1
+
+    print_test "Testing $broker_type connectivity"
+
+    if BROKER_TYPE=$broker_type "$SCRIPT_DIR/setup_env_unified.sh" &>/dev/null; then
+        print_success "$broker_type broker is reachable"
+        return 0
+    else
+        print_error "$broker_type broker is not reachable"
+        return 1
+    fi
+}
+
+# Function to send test message
+send_test_message() {
+    local broker_type=$1
+    local script_name=$2
+    local message_text=$3
+
+    print_test "Sending $script_name via $broker_type"
+
+    if BROKER_TYPE=$broker_type "$SCRIPT_DIR/$script_name" "$message_text" &>/dev/null; then
+        print_success "Message sent successfully via $broker_type"
+        return 0
+    else
+        print_error "Failed to send message via $broker_type"
+        return 1
+    fi
+}
+
+# Function to run comprehensive test suite
+run_test_suite() {
+    local broker_type=$1
+    local failures=0
+
+    print_section "Testing $broker_type Broker"
+
+    # Test connectivity first
+    if ! test_broker_connectivity "$broker_type"; then
+        print_error "Skipping $broker_type tests due to connectivity issues"
+        return 1
+    fi
+
+    # Test basic text message
+    if ! send_test_message "$broker_type" "produce_unified.sh" "$TEST_TEXT_MESSAGE"; then
+        ((failures++))
+    fi
+
+    # Test message with buttons
+    if ! send_test_message "$broker_type" "produce_with_buttons_unified.sh" "$TEST_BUTTON_MESSAGE"; then
+        ((failures++))
+    fi
+
+    # Test typing indicator
+    print_test "Sending typing indicator via $broker_type"
+    if BROKER_TYPE=$broker_type "$SCRIPT_DIR/produce_typing_unified.sh" &>/dev/null; then
+        print_success "Typing indicator sent successfully via $broker_type"
+    else
+        print_error "Failed to send typing indicator via $broker_type"
+        ((failures++))
+    fi
+
+    # Summary for this broker
+    if [ $failures -eq 0 ]; then
+        print_success "All tests passed for $broker_type broker"
+    else
+        print_error "$failures test(s) failed for $broker_type broker"
+    fi
+
+    return $failures
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    print_section "Checking Prerequisites"
+
+    local missing_tools=0
+
+    # Check for required tools
+    if ! command -v jq &>/dev/null; then
+        print_error "jq is required but not installed"
+        ((missing_tools++))
+    else
+        print_success "jq is available"
+    fi
+
+    if ! command -v uuidgen &>/dev/null; then
+        print_error "uuidgen is required but not installed"
+        ((missing_tools++))
+    else
+        print_success "uuidgen is available"
+    fi
+
+    # Check Kafka tools
+    if command -v kafka-console-producer &>/dev/null || command -v kafka-console-producer.sh &>/dev/null; then
+        print_success "Kafka tools are available"
+    else
+        print_warning "Kafka tools not found - Kafka tests will be skipped"
+        ((missing_tools++))
+    fi
+
+    # Check MQTT tools
+    if command -v mosquitto_pub &>/dev/null && command -v mosquitto_sub &>/dev/null; then
+        print_success "MQTT tools are available"
+    else
+        print_warning "MQTT tools not found - MQTT tests will be skipped"
+        ((missing_tools++))
+    fi
+
+    # Check CHAT_ID
+    if [ -z "$CHAT_ID" ]; then
+        print_error "CHAT_ID environment variable is not set"
+        echo "Please set your Telegram chat ID: export CHAT_ID=123456789"
+        ((missing_tools++))
+    else
+        print_success "CHAT_ID is set: $CHAT_ID"
+    fi
+
+    if [ $missing_tools -gt 0 ]; then
+        print_error "Some prerequisites are missing. Please install required tools."
+        exit 1
+    fi
+
+    print_success "All prerequisites are met"
+}
+
+# Function to show test results summary
+show_summary() {
+    local kafka_result=$1
+    local mqtt_result=$2
+
+    print_section "Test Results Summary"
+
+    echo -e "Kafka Tests: $([ $kafka_result -eq 0 ] && echo -e "${GREEN}PASSED${NC}" || echo -e "${RED}FAILED${NC}")"
+    echo -e "MQTT Tests:  $([ $mqtt_result -eq 0 ] && echo -e "${GREEN}PASSED${NC}" || echo -e "${RED}FAILED${NC}")"
+
+    if [ $kafka_result -eq 0 ] && [ $mqtt_result -eq 0 ]; then
+        print_success "All tests passed! Both brokers are working correctly."
+        echo ""
+        echo "Next steps:"
+        echo "  - Start consuming messages: make consume BROKER_TYPE=kafka"
+        echo "  - Or with MQTT: make consume BROKER_TYPE=mqtt"
+        echo "  - Run your Ratatoskr bot to see the messages delivered to Telegram"
+        return 0
+    else
+        print_error "Some tests failed. Check the output above for details."
+        echo ""
+        echo "Troubleshooting:"
+        if [ $kafka_result -ne 0 ]; then
+            echo "  - Kafka: Check if Kafka is running (make setup_kafka)"
+        fi
+        if [ $mqtt_result -ne 0 ]; then
+            echo "  - MQTT: Check if MQTT broker is running (make setup_mqtt)"
+        fi
+        echo "  - Verify CHAT_ID is correctly set"
+        echo "  - Check broker connectivity manually"
+        return 1
+    fi
+}
+
+# Function to demonstrate usage examples
+show_usage_examples() {
+    print_section "Usage Examples"
+
+    echo "After running this test, you can use these commands:"
+    echo ""
+    echo "Send messages via Kafka:"
+    echo "  make test_text BROKER_TYPE=kafka TEXT=\"Hello via Kafka\""
+    echo "  make test_buttons BROKER_TYPE=kafka TEXT=\"Buttons via Kafka\""
+    echo ""
+    echo "Send messages via MQTT:"
+    echo "  make test_text BROKER_TYPE=mqtt TEXT=\"Hello via MQTT\""
+    echo "  make test_buttons BROKER_TYPE=mqtt TEXT=\"Buttons via MQTT\""
+    echo ""
+    echo "Monitor messages:"
+    echo "  make consume BROKER_TYPE=kafka"
+    echo "  make consume BROKER_TYPE=mqtt"
+    echo ""
+    echo "Test both brokers quickly:"
+    echo "  make test_both_brokers"
+}
+
+# Main execution
+main() {
+    print_section "Ratatoskr Dual Broker Test Suite"
+    echo "Testing both Kafka and MQTT message delivery..."
+
+    # Check prerequisites
+    check_prerequisites
+
+    # Initialize results
+    kafka_result=1
+    mqtt_result=1
+
+    # Test Kafka
+    if command -v kafka-console-producer &>/dev/null || command -v kafka-console-producer.sh &>/dev/null; then
+        run_test_suite "kafka"
+        kafka_result=$?
+    else
+        print_warning "Skipping Kafka tests - tools not available"
+        kafka_result=0  # Don't fail if tools aren't installed
+    fi
+
+    # Test MQTT
+    if command -v mosquitto_pub &>/dev/null; then
+        run_test_suite "mqtt"
+        mqtt_result=$?
+    else
+        print_warning "Skipping MQTT tests - tools not available"
+        mqtt_result=0  # Don't fail if tools aren't installed
+    fi
+
+    # Show summary
+    show_summary $kafka_result $mqtt_result
+    result=$?
+
+    # Show usage examples
+    show_usage_examples
+
+    exit $result
+}
+
+# Handle script interruption
+trap 'echo -e "\n${YELLOW}Test interrupted by user${NC}"; exit 130' INT
+
+# Run main function
+main "$@"

--- a/src/broker/kafka.rs
+++ b/src/broker/kafka.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
+    producer::{FutureProducer, FutureRecord},
+    message::Message as KafkaMessage,
+};
+use futures_util::StreamExt;
+use crate::broker::{MessageBroker, BoxStream};
+use async_trait::async_trait;
+
+pub struct KafkaBroker {
+    producer: FutureProducer,
+    consumer: StreamConsumer,
+}
+
+impl KafkaBroker {
+    pub fn new(broker: &str) -> Result<Self> {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", broker)
+            .create()?;
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("group.id", "ratatoskr-broker")
+            .set("bootstrap.servers", broker)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "true")
+            .create()?;
+        Ok(Self { producer, consumer })
+    }
+}
+
+#[async_trait]
+impl MessageBroker for KafkaBroker {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        let record: FutureRecord<'_, (), _> = FutureRecord::to(topic).payload(payload);
+        self.producer
+            .send(record, None)
+            .await
+            .map(|_| ())
+            .map_err(|(e, _)| e.into())
+    }
+
+    async fn subscribe<'a>(&'a self, topic: &str) -> Result<BoxStream<'a, Vec<u8>>> {
+        self.consumer.subscribe(&[topic])?;
+        let stream = self
+            .consumer
+            .stream()
+            .filter_map(|msg| async move {
+                match msg {
+                    Ok(m) => m.payload().map(|p| p.to_vec()),
+                    Err(e) => {
+                        tracing::error!(error = %e, "Kafka consume error");
+                        None
+                    }
+                }
+            });
+        Ok(Box::pin(stream))
+    }
+}

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use tokio_stream::Stream;
+use std::pin::Pin;
+
+pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+
+#[async_trait]
+pub trait MessageBroker: Send + Sync {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> anyhow::Result<()>;
+    async fn subscribe<'a>(&'a self, topic: &str) -> anyhow::Result<BoxStream<'a, Vec<u8>>>;
+}
+
+pub mod kafka;
+pub mod mqtt;

--- a/src/broker/mqtt.rs
+++ b/src/broker/mqtt.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, Packet, QoS};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use futures_util::StreamExt;
+
+use crate::broker::{MessageBroker, BoxStream};
+use std::sync::Arc;
+
+pub struct MqttBroker {
+    client: AsyncClient,
+    sender: broadcast::Sender<Vec<u8>>,
+    eventloop: Arc<tokio::sync::Mutex<EventLoop>>, // protect eventloop polling
+}
+
+impl MqttBroker {
+    pub async fn new(broker: &str) -> Result<Self> {
+        let parts: Vec<&str> = broker.split(':').collect();
+        let host = parts.get(0).unwrap_or(&"localhost");
+        let port: u16 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(1883);
+        let mut mqttoptions = MqttOptions::new("ratatoskr-bot", host.to_string(), port);
+        mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
+        let (client, eventloop) = AsyncClient::new(mqttoptions, 10);
+        let (tx, _) = broadcast::channel(100);
+        let eventloop = Arc::new(tokio::sync::Mutex::new(eventloop));
+        let tx_clone = tx.clone();
+        let eventloop_clone = eventloop.clone();
+        tokio::spawn(async move {
+            loop {
+                let ev = {
+                    let mut evl = eventloop_clone.lock().await;
+                    evl.poll().await
+                };
+                match ev {
+                    Ok(Event::Incoming(Packet::Publish(p))) => {
+                        let _ = tx_clone.send(p.payload.to_vec());
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::error!(error = %e, "MQTT poll error");
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(Self { client, sender: tx, eventloop })
+    }
+}
+
+#[async_trait]
+impl MessageBroker for MqttBroker {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
+        self.client.publish(topic, QoS::AtLeastOnce, false, payload).await?;
+        Ok(())
+    }
+
+    async fn subscribe<'a>(&'a self, topic: &str) -> Result<BoxStream<'a, Vec<u8>>> {
+        self.client.subscribe(topic, QoS::AtLeastOnce).await?;
+        let rx = self.sender.subscribe();
+        let stream = BroadcastStream::new(rx).filter_map(|v| async move { v.ok() });
+        Ok(Box::pin(stream))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `MessageBroker` trait with Kafka and MQTT implementations
- add mqtt docker compose stack
- refactor handlers and main to use the broker abstraction
- update environment examples and README for selectable backend

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68540292e2f483318f3c8b5c47e7d85f